### PR TITLE
Testing the Library on Jetson platform and changing Depth and IR data type

### DIFF
--- a/examples/exampleColorImageOpenCV.py
+++ b/examples/exampleColorImageOpenCV.py
@@ -7,8 +7,8 @@ import cv2
 
 # Path to the module
 # TODO: Modify with the path containing the k4a.dll from the Azure Kinect SDK
-modulePath = 'C:\\Program Files\\Azure Kinect SDK v1.4.1\\sdk\\windows-desktop\\amd64\\release\\bin\\k4a.dll'
-# under linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
+modulePath = '/usr/lib/aarch64-linux-gnu/libk4a.so'  #set path for libk4a.so library in Jetson 
+# under x86_64 linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
 
 if __name__ == "__main__":
 

--- a/examples/exampleDepthImageOpenCV.py
+++ b/examples/exampleDepthImageOpenCV.py
@@ -7,7 +7,7 @@ import cv2
 
 # Path to the module
 # TODO: Modify with the path containing the k4a.dll from the Azure Kinect SDK
-modulePath = '/usr/lib/aarch64-linux-gnu/libk4a.so'  #Set path for libk4a.so library in Jetson
+modulePath = '/usr/lib/aarch64-linux-gnu/libk4a.so'  #set path for libk4a.so library in Jetson
 # under x86_64 linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
 
 if __name__ == "__main__":
@@ -40,14 +40,11 @@ if __name__ == "__main__":
 
 			# Read and convert the image data to numpy array:
 			depth_image = pyK4A.image_convert_to_numpy(depth_image_handle)
-
-			# Convert depth image (mm) to color, the range needs to be reduced down to the range (0,255)
-			depth_color_image = cv2.applyColorMap(np.round(depth_image/30).astype(np.uint8), cv2.COLORMAP_JET)
-
-			# Plot the image
+			depth_color_image = cv2.convertScaleAbs (depth_image, alpha=0.05)  #alpha is fitted by visual comparison with Azure k4aviewer results  
+			depth_color_image = cv2.applyColorMap(depth_color_image, cv2.COLORMAP_JET)
 			cv2.namedWindow('Colorized Depth Image',cv2.WINDOW_NORMAL)
 			cv2.imshow('Colorized Depth Image',depth_color_image)
-			k = cv2.waitKey(25)
+			k = cv2.waitKey(1)
 
 			# Release the image
 			pyK4A.image_release(depth_image_handle)

--- a/examples/exampleDepthImageOpenCV.py
+++ b/examples/exampleDepthImageOpenCV.py
@@ -7,8 +7,8 @@ import cv2
 
 # Path to the module
 # TODO: Modify with the path containing the k4a.dll from the Azure Kinect SDK
-modulePath = 'C:\\Program Files\\Azure Kinect SDK v1.4.1\\sdk\\windows-desktop\\amd64\\release\\bin\\k4a.dll'
-# under linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
+modulePath = '/usr/lib/aarch64-linux-gnu/libk4a.so'  #Set path for libk4a.so library in Jetson
+# under x86_64 linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
 
 if __name__ == "__main__":
 

--- a/examples/exampleInfraredImageOpenCV.py
+++ b/examples/exampleInfraredImageOpenCV.py
@@ -7,8 +7,8 @@ import cv2
 
 # Path to the module
 # TODO: Modify with the path containing the k4a.dll from the Azure Kinect SDK
-modulePath = 'C:\\Program Files\\Azure Kinect SDK v1.4.1\\sdk\\windows-desktop\\amd64\\release\\bin\\k4a.dll'
-# under linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
+modulePath = '/usr/lib/aarch64-linux-gnu/libk4a.so'  #set path for libk4a.so library in Jetson 
+# under x86_64 linux please use r'/usr/lib/x86_64-linux-gnu/libk4a.so'
 
 if __name__ == "__main__":
 
@@ -42,15 +42,13 @@ if __name__ == "__main__":
 
 			# Read and convert the image data to numpy array:
 			ir_image = pyK4A.image_convert_to_numpy(ir_image_handle)
-
+   
 			# Convert to 0-255 range and saturate over 4000 pixel value
-			image_to_show = ir_image*1
-			image_to_show[image_to_show>4000] = 4000
-			image_to_show = np.round(image_to_show/16).astype(np.uint8)
-
-			# Plot the image
+			image_to_show = ir_image
+			image_to_show[image_to_show>4000] = 4000 
+			image_to_show =cv2.convertScaleAbs(image_to_show, alpha=0.4)  #alpha is fitted by visual comparison with Azure k4aviewer results     
 			cv2.imshow('Infrared Image',image_to_show)
-			k = cv2.waitKey(25)
+			k = cv2.waitKey(1)  
 
 			# Release the image
 			pyK4A.image_release(ir_image_handle)

--- a/pyKinectAzure/pyKinectAzure.py
+++ b/pyKinectAzure/pyKinectAzure.py
@@ -506,9 +506,9 @@ class pyKinectAzure:
 		elif image_format == _k4a.K4A_IMAGE_FORMAT_COLOR_BGRA32:
 			return np.frombuffer(buffer_array, dtype=np.uint8).reshape(image_height,image_width,4)
 		elif image_format == _k4a.K4A_IMAGE_FORMAT_DEPTH16:
-			return np.frombuffer(buffer_array, dtype="<i2").reshape(image_height,image_width)
+			return np.frombuffer(buffer_array, dtype="<u2").reshape(image_height,image_width)#little-endian 16 bits unsigned Depth data
 		elif image_format == _k4a.K4A_IMAGE_FORMAT_IR16:
-			return np.frombuffer(buffer_array, dtype="<i2").reshape(image_height,image_width)
+			return np.frombuffer(buffer_array, dtype="<u2").reshape(image_height,image_width)#little-endian 16 bits unsigned IR data. For more details see: https://microsoft.github.io/Azure-Kinect-Sensor-SDK/release/1.2.x/namespace_microsoft_1_1_azure_1_1_kinect_1_1_sensor_a7a3cb7a0a3073650bf17c2fef2bfbd1b.html
 
 	def transform_depth_to_color(self,input_depth_image_handle, color_image_handle):
 		calibration = _k4a.k4a_calibration_t()


### PR DESCRIPTION
The pull request is intended to test the library on Jetson platform (Ubuntu 18.04, Kinect SDK 1.4, Python3.6, OpenCV4) and change data type of Depth and IR images (replace int16 by uint16).