### PR TITLE
Update frame.py removing timestamp bug

### DIFF
--- a/pykinect_azure/k4abt/frame.py
+++ b/pykinect_azure/k4abt/frame.py
@@ -90,7 +90,7 @@ class Frame:
 		return _k4abt.k4abt_frame_get_device_timestamp_usec(self._handle)
 
 	def get_body_index_map(self):
-		return Image(_k4abt.k4abt_frame_get_body_index_map(self._handle))
+		return _k4abt.k4abt_frame_get_body_index_map(self._handle)
 
 	def get_body_index_map_image(self):
 		return self.get_body_index_map().to_numpy()

--- a/pykinect_azure/k4abt/frame.py
+++ b/pykinect_azure/k4abt/frame.py
@@ -87,7 +87,7 @@ class Frame:
 		return self.get_body2d(bodyIdx, dest_camera).draw(destination_image, only_segments)
 
 	def get_device_timestamp_usec(self):
-		return Image(_k4abt.k4abt_frame_get_device_timestamp_usec(self._handle))
+		return _k4abt.k4abt_frame_get_device_timestamp_usec(self._handle)
 
 	def get_body_index_map(self):
 		return Image(_k4abt.k4abt_frame_get_body_index_map(self._handle))


### PR DESCRIPTION
Removed Image conversion in get_device_timestamp_usec in order to return numerical type rather than Image type for device timestamp