### PR TITLE
Extend the amount of information given by Joint.numpy()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 examples/outputImage.jpg
 venv/
 .idea/
+
+# test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 
 *.pyc
 examples/outputImage.jpg
-venv/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 examples/outputImage.jpg
 venv/
 .idea/
-
-# test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 *.pyc
 examples/outputImage.jpg
+venv/
+.idea/

--- a/pykinect_azure/k4abt/joint.py
+++ b/pykinect_azure/k4abt/joint.py
@@ -17,7 +17,8 @@ class Joint:
 		self.destroy()
 
 	def numpy(self):
-		return np.array([self.position.x, self.position.y, self.position.z,
+		return np.array([self.id,
+						 self.position.x, self.position.y, self.position.z,
 						 self.orientation.w, self.orientation.x, self.orientation.y, self.orientation.z,
 						 self.confidence_level])
 

--- a/pykinect_azure/k4abt/joint.py
+++ b/pykinect_azure/k4abt/joint.py
@@ -17,7 +17,9 @@ class Joint:
 		self.destroy()
 
 	def numpy(self):
-		return np.array([self.position.x,self.position.y,self.position.z])
+		return np.array([self.position.x, self.position.y, self.position.z,
+						 self.orientation.w, self.orientation.x, self.orientation.y, self.orientation.z,
+						 self.confidence_level])
 
 	def is_valid(self):
 		return self._handle

--- a/pykinect_azure/k4abt/joint.py
+++ b/pykinect_azure/k4abt/joint.py
@@ -17,8 +17,7 @@ class Joint:
 		self.destroy()
 
 	def numpy(self):
-		return np.array([self.id,
-						 self.position.x, self.position.y, self.position.z,
+		return np.array([self.position.x, self.position.y, self.position.z,
 						 self.orientation.w, self.orientation.x, self.orientation.y, self.orientation.z,
 						 self.confidence_level])
 


### PR DESCRIPTION
The numpy array returned when calling Joint.numpy() gives an array containing the x position, the y position, and the z position, in that order.
This change adds more information about the joint to the numpy array, which now looks like such:
The x position, the y position, the z position, the w orientation, the x orientation, the y orientation, the z orientation, and the confidence level, in that order.