### PR TITLE
Fix/body ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/pykinect_azure/k4abt/_k4abtTypes.py
+++ b/pykinect_azure/k4abt/_k4abtTypes.py
@@ -5,14 +5,14 @@ from pykinect_azure.k4a._k4atypes import k4a_float3_t, k4a_float2_t
 
 # K4A_DECLARE_HANDLE(k4abt_tracker_t);
 class _handle_k4abt_tracker_t(ctypes.Structure):
-	 _fields_= [
+	_fields_ = [
 		("_rsvd", ctypes.c_size_t),
 	]
 k4abt_tracker_t = ctypes.POINTER(_handle_k4abt_tracker_t)
 
 # K4A_DECLARE_HANDLE(k4abt_frame_t);
 class _handle_k4abt_frame_t(ctypes.Structure):
-	 _fields_= [
+	_fields_ = [
 		("_rsvd", ctypes.c_size_t),
 	]
 k4abt_frame_t = ctypes.POINTER(_handle_k4abt_frame_t)
@@ -21,7 +21,7 @@ k4abt_result_t = ctypes.c_int
 K4ABT_RESULT_SUCCEEDED = 0
 K4ABT_RESULT_FAILED = 1
 
-#class k4abt_joint_id_t(CtypeIntEnum):
+# class k4abt_joint_id_t(CtypeIntEnum):
 K4ABT_JOINT_PELVIS = 0
 K4ABT_JOINT_SPINE_NAVEL = 1
 K4ABT_JOINT_SPINE_CHEST = 2
@@ -61,48 +61,48 @@ K4ABT_JOINT_NAMES = ["pelvis", "spine - navel", "spine - chest", "neck", "left c
 					"right wrist", "right hand", "right handtip", "right thumb", "left hip", "left knee", "left ankle", "left foot",
 					"right hip", "right knee", "right ankle", "right foot", "head", "nose", "left eye", "left ear","right eye", "right ear"]
 
-K4ABT_SEGMENT_PAIRS = [[1, 0], 
-					   [2, 1], 
-					   [3, 2], 
-					   [4, 2], 
-					   [5, 4], 
-					   [6, 5], 
-					   [7, 6], 
-					   [8, 7], 
+K4ABT_SEGMENT_PAIRS = [[1, 0],
+					   [2, 1],
+					   [3, 2],
+					   [4, 2],
+					   [5, 4],
+					   [6, 5],
+					   [7, 6],
+					   [8, 7],
 					   [9, 8],
-					   [10, 7], 
-					   [11, 2], 
-					   [12, 11], 
-					   [13, 12], 
-					   [14, 13], 
-					   [15, 14], 
-					   [16, 15], 
-					   [17, 14], 
-					   [18, 0], 
+					   [10, 7],
+					   [11, 2],
+					   [12, 11],
+					   [13, 12],
+					   [14, 13],
+					   [15, 14],
+					   [16, 15],
+					   [17, 14],
+					   [18, 0],
 					   [19, 18],
-					   [20, 19], 
-					   [21, 20], 
-					   [22, 0], 
-					   [23, 22], 
-					   [24, 23], 
-					   [25, 24], 
-					   [26, 3], 
+					   [20, 19],
+					   [21, 20],
+					   [22, 0],
+					   [23, 22],
+					   [24, 23],
+					   [25, 24],
+					   [26, 3],
 					   [27, 26],
-					   [28, 26], 
-					   [29, 26], 
-					   [30, 26], 
+					   [28, 26],
+					   [29, 26],
+					   [30, 26],
 					   [31, 26]]
 
-#class k4abt_sensor_orientation_t(CtypeIntEnum):
+# class k4abt_sensor_orientation_t(CtypeIntEnum):
 K4ABT_SENSOR_ORIENTATION_DEFAULT = 0
 K4ABT_SENSOR_ORIENTATION_CLOCKWISE90 = 1
 K4ABT_SENSOR_ORIENTATION_COUNTERCLOCKWISE90 = 2
 K4ABT_SENSOR_ORIENTATION_FLIP180 = 3
 
-#class k4abt_tracker_processing_mode_t(CtypeIntEnum):
+# class k4abt_tracker_processing_mode_t(CtypeIntEnum):
 K4ABT_TRACKER_PROCESSING_MODE_GPU = 0
 K4ABT_TRACKER_PROCESSING_MODE_CPU = 1
-K4ABT_TRACKER_PROCESSING_MODE_GPU_CUDA = 2     
+K4ABT_TRACKER_PROCESSING_MODE_GPU_CUDA = 2
 K4ABT_TRACKER_PROCESSING_MODE_GPU_TENSORRT = 3
 K4ABT_TRACKER_PROCESSING_MODE_GPU_DIRECTML = 4
 
@@ -148,7 +148,7 @@ class k4a_quaternion_t(ctypes.Union):
 	def __str__(self):
 		return self.wxyz.__str__()
 
-#class k4abt_joint_confidence_level_t(CtypeIntEnum):
+# class k4abt_joint_confidence_level_t(CtypeIntEnum):
 K4ABT_JOINT_CONFIDENCE_NONE = 0
 K4ABT_JOINT_CONFIDENCE_LOW = 1
 K4ABT_JOINT_CONFIDENCE_MEDIUM = 2
@@ -157,7 +157,7 @@ K4ABT_JOINT_CONFIDENCE_LEVELS_COUNT = 4
 
 
 class _k4abt_joint_t(ctypes.Structure):
-	_fields_= [
+	_fields_ = [
 		("position", k4a_float3_t),
 		("orientation", k4a_quaternion_t),
 		("confidence_level", ctypes.c_int),
@@ -170,14 +170,14 @@ class _k4abt_joint_t(ctypes.Structure):
 		self.confidence_level = confidence_level
 
 	def __iter__(self):
-		return {'position':self.position.__iter__(), 
+		return {'position':self.position.__iter__(),
 				'orientation':self.orientation.__iter__(),
 				'confidence_level':self.confidence_level}
 
 k4abt_joint_t = _k4abt_joint_t
 
 class k4abt_skeleton_t(ctypes.Structure):
-	_fields_= [
+	_fields_ = [
 		("joints", _k4abt_joint_t * K4ABT_JOINT_COUNT),
 	]
 
@@ -190,7 +190,7 @@ class k4abt_skeleton_t(ctypes.Structure):
 
 
 class k4abt_body_t(ctypes.Structure):
-	_fields_= [
+	_fields_ = [
 		("id", ctypes.c_uint32),
 		("skeleton", k4abt_skeleton_t),
 	]
@@ -204,7 +204,7 @@ class k4abt_body_t(ctypes.Structure):
 		return {'id':self.id, 'skeleton': self.skeleton.__iter__()}
 
 class _k4abt_joint2D_t(ctypes.Structure):
-	_fields_= [
+	_fields_ = [
 		("position", k4a_float2_t),
 		("confidence_level", ctypes.c_int),
 	]
@@ -215,13 +215,15 @@ class _k4abt_joint2D_t(ctypes.Structure):
 		self.confidence_level = confidence_level
 
 	def __iter__(self):
-		return {'position':self.position.__iter__(),
-				'confidence_level':self.confidence_level}
+		return {
+			'position': self.position.__iter__(),
+			'confidence_level': self.confidence_level
+		}
 
 k4abt_joint2D_t = _k4abt_joint2D_t
 
 class k4abt_skeleton2D_t(ctypes.Structure):
-	_fields_= [
+	_fields_ = [
 		("joints2D", _k4abt_joint2D_t * K4ABT_JOINT_COUNT),
 	]
 
@@ -233,7 +235,7 @@ class k4abt_skeleton2D_t(ctypes.Structure):
 		return {'joints2D': [joint.__iter__() for joint in self.joints2D]}
 
 class k4abt_body2D_t(ctypes.Structure):
-	_fields_= [
+	_fields_ = [
 		("id", ctypes.c_uint32),
 		("skeleton", k4abt_skeleton2D_t),
 	]
@@ -244,7 +246,10 @@ class k4abt_body2D_t(ctypes.Structure):
 		self.skeleton = skeleton
 
 	def __iter__(self):
-		return {'id':self.id, 'skeleton': self.skeleton.__iter__()}
+		return {
+			'id': self.id,
+			'skeleton': self.skeleton.__iter__()
+		}
 
 
 K4ABT_BODY_INDEX_MAP_BACKGROUND = 255
@@ -259,5 +264,13 @@ k4abt_tracker_default_configuration.sensor_orientation = K4ABT_SENSOR_ORIENTATIO
 k4abt_tracker_default_configuration.processing_mode = K4ABT_TRACKER_PROCESSING_MODE_GPU
 k4abt_tracker_default_configuration.gpu_device_id = 0
 
-body_colors = np.ones((256,3), dtype=np.uint8)*K4ABT_BODY_INDEX_MAP_BACKGROUND
-body_colors[:7,:] = np.array([[202, 183, 42], [42, 61, 202], [42, 202, 183], [202, 42,61], [183, 42, 202], [42, 202, 61], [141, 202, 42]]) 
+body_colors = np.ones((256, 3), dtype=np.uint8) * K4ABT_BODY_INDEX_MAP_BACKGROUND
+body_colors[:7, :] = np.array([
+	[202, 183, 42],
+	[42, 61, 202],
+	[42, 202, 183],
+	[202, 42, 61],
+	[183, 42, 202],
+	[42, 202, 61],
+	[141, 202, 42]
+])

--- a/pykinect_azure/k4abt/_k4abtTypes.py
+++ b/pykinect_azure/k4abt/_k4abtTypes.py
@@ -163,16 +163,18 @@ class _k4abt_joint_t(ctypes.Structure):
 		("confidence_level", ctypes.c_int),
 	]
 
-	def __init__(self, position=(0,0,0), orientation=(0,0,0,0), confidence_level=0):
+	def __init__(self, position=(0, 0, 0), orientation=(0, 0, 0, 0), confidence_level=0):
 		super().__init__()
 		self.position = k4a_float3_t(position)
 		self.orientation = k4a_quaternion_t(orientation)
 		self.confidence_level = confidence_level
 
 	def __iter__(self):
-		return {'position':self.position.__iter__(),
-				'orientation':self.orientation.__iter__(),
-				'confidence_level':self.confidence_level}
+		return {
+			'position': self.position.__iter__(),
+			'orientation': self.orientation.__iter__(),
+			'confidence_level': self.confidence_level
+		}
 
 k4abt_joint_t = _k4abt_joint_t
 
@@ -201,7 +203,10 @@ class k4abt_body_t(ctypes.Structure):
 		self.skeleton = skeleton
 
 	def __iter__(self):
-		return {'id':self.id, 'skeleton': self.skeleton.__iter__()}
+		return {
+			'id': self.id,
+			'skeleton': self.skeleton.__iter__()
+		}
 
 class _k4abt_joint2D_t(ctypes.Structure):
 	_fields_ = [
@@ -209,7 +214,7 @@ class _k4abt_joint2D_t(ctypes.Structure):
 		("confidence_level", ctypes.c_int),
 	]
 
-	def __init__(self, position=(0,0), confidence_level=0):
+	def __init__(self, position=(0, 0), confidence_level=0):
 		super().__init__()
 		self.position = k4a_float2_t(position)
 		self.confidence_level = confidence_level

--- a/pykinect_azure/k4abt/body2d.py
+++ b/pykinect_azure/k4abt/body2d.py
@@ -6,16 +6,16 @@ from pykinect_azure.k4abt._k4abtTypes import K4ABT_JOINT_COUNT, K4ABT_SEGMENT_PA
 from pykinect_azure.k4abt._k4abtTypes import k4abt_skeleton2D_t, k4abt_body2D_t, body_colors
 from pykinect_azure.k4a._k4atypes import K4A_CALIBRATION_TYPE_DEPTH
 
+
 class Body2d:
 	def __init__(self, body2d_handle):
-
+		self.joints = None
 		if body2d_handle:
 			self._handle = body2d_handle
 			self.id = body2d_handle.id
 			self.initialize_skeleton()
 
 	def __del__(self):
-
 		self.destroy()
 
 	def json(self):
@@ -34,18 +34,24 @@ class Body2d:
 		if self.is_valid():
 			self._handle = None
 
+	@property
+	def color(self, unique_colors=200):
+		total_colors = 256 ** 3
+		hex_color = self.id * int(total_colors / unique_colors)
+		r = (hex_color >> 16) & 0xFF
+		g = (hex_color >> 8) & 0xFF
+		b = hex_color & 0xFF
+		return [r, g, b]
+
 	def initialize_skeleton(self):
-		joints = np.ndarray((K4ABT_JOINT_COUNT,),dtype=np.object_)
+		joints = np.ndarray((K4ABT_JOINT_COUNT,), dtype=np.object_)
 
 		for i in range(K4ABT_JOINT_COUNT):
 			joints[i] = Joint2d(self._handle.skeleton.joints2D[i], i)
 
 		self.joints = joints
 
-	def draw(self, image, only_segments = False):
-
-		color = (int (body_colors[self.id][0]), int (body_colors[self.id][1]), int (body_colors[self.id][2]))
-
+	def draw(self, image, only_segments=False):
 		for segmentId in range(len(K4ABT_SEGMENT_PAIRS)):
 			segment_pair = K4ABT_SEGMENT_PAIRS[segmentId]
 			point1 = self.joints[segment_pair[0]].get_coordinates()
@@ -53,32 +59,30 @@ class Body2d:
 
 			if (point1[0] == 0 and point1[1] == 0) or (point2[0] == 0 and point2[1] == 0):
 				continue
-			image = cv2.line(image, point1, point2,color, 2)
+			image = cv2.line(image, point1, point2, self.color, 2)
 
 		if only_segments:
 			return image
 
 		for joint in self.joints:
-			image = cv2.circle(image, joint.get_coordinates(), 3, color, 3)
+			image = cv2.circle(image, joint.get_coordinates(), 3, self.color, 3)
 
 		return image
 
-
 	@staticmethod
-	def create(body_handle, calibration, bodyIdx, dest_camera):
+	def create(body_handle, calibration, body_index, dest_camera):
 
 		skeleton2d_handle = k4abt_skeleton2D_t()
 		body2d_handle = k4abt_body2D_t()
 
-		for jointID,joint in enumerate(body_handle.skeleton.joints): 
+		for jointID, joint in enumerate(body_handle.skeleton.joints):
 			skeleton2d_handle.joints2D[jointID].position = calibration.convert_3d_to_2d(joint.position, K4A_CALIBRATION_TYPE_DEPTH, dest_camera)
 			skeleton2d_handle.joints2D[jointID].confidence_level = joint.confidence_level
 
 		body2d_handle.skeleton = skeleton2d_handle
-		body2d_handle.id = bodyIdx
+		body2d_handle.id = body_index
 
 		return Body2d(body2d_handle)
-
 
 	def __str__(self):
 		"""Print the current settings and a short explanation"""

--- a/pykinect_azure/k4abt/frame.py
+++ b/pykinect_azure/k4abt/frame.py
@@ -1,5 +1,5 @@
 import numpy as np
-import cv2 
+import cv2
 
 from pykinect_azure.k4abt import _k4abt
 from pykinect_azure.k4abt.body import Body
@@ -50,7 +50,7 @@ class Frame:
 
 	def get_body_skeleton(self, index=0):
 		skeleton = _k4abt.k4abt_skeleton_t()
-		_k4abt.VERIFY(_k4abt.k4abt_frame_get_body_skeleton(self._handle,index, skeleton),"Body tracker get body skeleton failed!")
+		_k4abt.VERIFY(_k4abt.k4abt_frame_get_body_skeleton(self._handle, index, skeleton), "Body tracker get body skeleton failed!")
 		return skeleton
 
 	def get_body_id(self, index=0):
@@ -102,7 +102,7 @@ class Frame:
 		return self.get_body_index_map().to_numpy()
 
 	def get_transformed_body_index_map(self):
-		depth_image = self.get_capture().get_depth_image_object()	
+		depth_image = self.get_capture().get_depth_image_object()
 		return self.transformation.depth_image_to_color_camera_custom(depth_image, self.get_body_index_map())
 
 	def get_transformed_body_index_map_image(self):
@@ -111,12 +111,12 @@ class Frame:
 
 	def get_segmentation_image(self):
 		ret, body_index_map = self.get_body_index_map_image()
-		return ret, np.dstack([cv2.LUT(body_index_map, body_colors[:,i]) for i in range(3)])
+		return ret, np.dstack([cv2.LUT(body_index_map, body_colors[:, i]) for i in range(3)])
 
 	def get_transformed_segmentation_image(self):
 		ret, transformed_body_index_map = self.get_transformed_body_index_map_image()
-		return ret, np.dstack([cv2.LUT(transformed_body_index_map, body_colors[:,i]) for i in range(3)])
-		
+		return ret, np.dstack([cv2.LUT(transformed_body_index_map, body_colors[:, i]) for i in range(3)])
+
 	def get_capture(self):
 		return Capture(_k4abt.k4abt_frame_get_capture(self._handle), self.calibration._handle)
 

--- a/pykinect_azure/k4abt/frame.py
+++ b/pykinect_azure/k4abt/frame.py
@@ -8,6 +8,7 @@ from pykinect_azure.k4abt._k4abtTypes import k4abt_body_t, body_colors
 from pykinect_azure.k4a import Image, Capture, Transformation
 from pykinect_azure.k4a._k4atypes import K4A_CALIBRATION_TYPE_DEPTH
 
+
 class Frame:
 	def __init__(self, frame_handle, calibration):
 
@@ -49,9 +50,7 @@ class Frame:
 
 	def get_body_skeleton(self, index=0):
 		skeleton = _k4abt.k4abt_skeleton_t()
-
-		_k4abt.VERIFY(_k4abt.k4abt_frame_get_body_skeleton(self._handle, index, skeleton), "Body tracker get body skeleton failed!")
-
+		_k4abt.VERIFY(_k4abt.k4abt_frame_get_body_skeleton(self._handle,index, skeleton),"Body tracker get body skeleton failed!")
 		return skeleton
 
 	def get_body_id(self, index=0):
@@ -71,20 +70,18 @@ class Frame:
 
 		return bodies
 
-	def get_body(self, bodyIdx = 0):
+	def get_body(self, body_index=0):
 		body_handle = k4abt_body_t()
-		body_handle.id = self.get_body_id(bodyIdx);
-		body_handle.skeleton = self.get_body_skeleton(bodyIdx);
+		body_handle.id = self.get_body_id(body_index)
+		body_handle.skeleton = self.get_body_skeleton(body_index)
 
 		return Body(body_handle)
 
-	def get_body2d(self, bodyIdx = 0, dest_camera = K4A_CALIBRATION_TYPE_DEPTH):
+	def get_body2d(self, body_index=0, dest_camera=K4A_CALIBRATION_TYPE_DEPTH):
+		body_handle = self.get_body(body_index).handle()
+		return Body2d.create(body_handle, self.calibration, body_handle.id, dest_camera)
 
-		body_handle = self.get_body(bodyIdx).handle()
-
-		return Body2d.create(body_handle, self.calibration, bodyIdx, dest_camera)
-
-	def draw_bodies(self, destination_image, dest_camera = K4A_CALIBRATION_TYPE_DEPTH, only_segments = False):
+	def draw_bodies(self, destination_image, dest_camera=K4A_CALIBRATION_TYPE_DEPTH, only_segments=False):
 		num_bodies = self.get_num_bodies()
 
 		for body_id in range(num_bodies):
@@ -92,8 +89,8 @@ class Frame:
 
 		return destination_image
 
-	def draw_body2d(self, destination_image, bodyIdx = 0, dest_camera = K4A_CALIBRATION_TYPE_DEPTH, only_segments = False):
-		return self.get_body2d(bodyIdx, dest_camera).draw(destination_image, only_segments)
+	def draw_body2d(self, destination_image, body_index=0, dest_camera=K4A_CALIBRATION_TYPE_DEPTH, only_segments=False):
+		return self.get_body2d(body_index, dest_camera).draw(destination_image, only_segments)
 
 	def get_device_timestamp_usec(self):
 		return _k4abt.k4abt_frame_get_device_timestamp_usec(self._handle)
@@ -109,7 +106,7 @@ class Frame:
 		return self.transformation.depth_image_to_color_camera_custom(depth_image, self.get_body_index_map())
 
 	def get_transformed_body_index_map_image(self):
-		transformed_body_index_map =self.get_transformed_body_index_map()
+		transformed_body_index_map = self.get_transformed_body_index_map()
 		return transformed_body_index_map.to_numpy()
 
 	def get_segmentation_image(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 opencv-python
-
+numpy
 


### PR DESCRIPTION
Fix for a bug when tracking multiple skeletons. In a couple of places (and I imagine a couple more that I didn't find) the body_id is confused with the bodyIdx.

These changes also include a better implementation of how body colors are chosen, but it is not implemented everywhere (such as in Frame.get_segmentation_image()). By default a new computed property of the Body2D class "color" generates a unique color for the first 200 IDs, that will always be same. The 200 unique colors can be changed by passing a property to the "color" property of  the Body2D class.