### PR TITLE
Fixed bug in tracker configuration

### DIFF
--- a/pykinect_azure/k4abt/frame.py
+++ b/pykinect_azure/k4abt/frame.py
@@ -15,7 +15,6 @@ class Frame:
 			self._handle = frame_handle
 			self.calibration = calibration
 			self.transformation = Transformation(self.calibration)
-			_k4abt.k4abt_frame_reference(self._handle)
 
 	def __del__(self):
 		self.reset()

--- a/pykinect_azure/k4abt/trackerconfiguration.py
+++ b/pykinect_azure/k4abt/trackerconfiguration.py
@@ -17,7 +17,7 @@ class TrackerConfiguration:
 
         if hasattr(self, name):
             if name != "_handle":
-                if int(self.__dict__[name]) != value:
+                if self.__dict__[name] != value:
                     self.__dict__[name] = value
                     self.on_value_change()
             else:
@@ -40,6 +40,7 @@ class TrackerConfiguration:
         self.sensor_orientation = _k4abt.K4ABT_SENSOR_ORIENTATION_DEFAULT
         self.tracker_processing_mode = _k4abt.K4ABT_TRACKER_PROCESSING_MODE_GPU
         self.gpu_device_id = 0
+        self.model_path = None
 
         self.on_value_change()
 
@@ -51,7 +52,7 @@ class TrackerConfiguration:
 
     def on_value_change(self):
         handle = None
-        if hasattr(self, "_model_path"):
+        if hasattr(self, "model_path") and self.model_path is not None:
             handle = _k4abt.k4abt_tracker_configuration_t(self.sensor_orientation,
                                                                 self.tracker_processing_mode,
                                                                 self.gpu_device_id,

--- a/pykinect_azure/pykinect.py
+++ b/pykinect_azure/pykinect.py
@@ -50,7 +50,7 @@ def start_device(device_index=0, config=default_configuration, record=False, rec
 
     return device
 
-def start_body_tracker(model_type=default_tracker_configuration, calibration=None, tracker_configuration=default_tracker_configuration):
+def start_body_tracker(model_type=_k4abt.K4ABT_DEFAULT_MODEL, calibration=None, tracker_configuration=default_tracker_configuration):
     if not calibration:
         calibration = Device.calibration
 


### PR DESCRIPTION
There was a bug in the tracker configuration.
The initializer used default_tracker_configuration instead of K4ABT_DEFAULT_MODEL as an input and, as a result, the light model could never be used.